### PR TITLE
Refactor: Create reusable components and enhance UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/MyAlertDialog.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/MyAlertDialog.kt
@@ -1,16 +1,20 @@
 package jva.cloud.democomposemultiplatform.presentation.components
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
 import democomposemultiplatform.composeapp.generated.resources.Res
 import democomposemultiplatform.composeapp.generated.resources.cancel_button_text
 import democomposemultiplatform.composeapp.generated.resources.info_icon_content_description
 import democomposemultiplatform.composeapp.generated.resources.ok_button_text
+import jva.cloud.democomposemultiplatform.presentation.components.model.AlertType
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -18,10 +22,13 @@ internal fun MyAlertDialog(
     showDialog: Boolean,
     title: String,
     text: String,
+    alertType: AlertType,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit
 ) {
     if (showDialog) {
+        val icon: ImageVector = getIcon(alertType)
+
         AlertDialog(
             onDismissRequest = { onDismiss() },
             confirmButton = {
@@ -30,18 +37,28 @@ internal fun MyAlertDialog(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { onDismiss() }) {
-                    Text(text = stringResource(Res.string.cancel_button_text))
+                if (alertType != AlertType.SUCCESS) {
+                    TextButton(onClick = { onDismiss() }) {
+                        Text(text = stringResource(Res.string.cancel_button_text))
+                    }
                 }
             },
             title = { Text(text = title) },
             text = { Text(text = text) },
             icon = {
                 Icon(
-                    imageVector = Icons.Default.Info,
+                    imageVector = icon,
                     contentDescription = stringResource(Res.string.info_icon_content_description)
                 )
             }
         )
+    }
+}
+
+private fun getIcon(alertType: AlertType): ImageVector {
+    return when (alertType) {
+        AlertType.SUCCESS -> Icons.Default.CheckCircle
+        AlertType.ERROR -> Icons.Default.Error
+        AlertType.INFO -> Icons.Default.Info
     }
 }

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/MyButton.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/MyButton.kt
@@ -1,0 +1,27 @@
+package jva.cloud.democomposemultiplatform.presentation.components
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun MyButton(
+    text: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(8.dp)
+) {
+    Button(
+        enabled = enabled,
+        onClick = { onClick() },
+        modifier = modifier,
+        shape = shape
+    ) {
+        Text(text = text)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/SectionHeader.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/SectionHeader.kt
@@ -1,0 +1,30 @@
+package jva.cloud.democomposemultiplatform.presentation.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun SectionHeader(
+    text: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = text,
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        Text(text = text)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/model/AlertType.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/components/model/AlertType.kt
@@ -1,0 +1,7 @@
+package jva.cloud.democomposemultiplatform.presentation.components.model
+
+enum class AlertType {
+    SUCCESS,
+    ERROR,
+    INFO
+}

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/createaccount/CreateAccountView.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/createaccount/CreateAccountView.kt
@@ -10,13 +10,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,9 +40,13 @@ import democomposemultiplatform.composeapp.generated.resources.sign_up_subtitle
 import democomposemultiplatform.composeapp.generated.resources.success_title
 import jva.cloud.democomposemultiplatform.presentation.components.LoadingIndicator
 import jva.cloud.democomposemultiplatform.presentation.components.MyAlertDialog
+import jva.cloud.democomposemultiplatform.presentation.components.MyButton
 import jva.cloud.democomposemultiplatform.presentation.components.MyOutLinedTextField
+import jva.cloud.democomposemultiplatform.presentation.components.SectionHeader
+import jva.cloud.democomposemultiplatform.presentation.components.model.AlertType
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.createaccount.CreateAccountError
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.createaccount.CreateAccountViewModel
+import jva.cloud.democomposemultiplatform.presentation.viewmodel.createaccount.CreateAccountViewModelState
 import jva.cloud.democomposemultiplatform.utils.ConstantApp.STRING_EMPTY
 import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.stringResource
@@ -57,110 +58,100 @@ object CreateAccount
 @Composable
 fun CreateAccountView(onSignIn: () -> Unit, vm: CreateAccountViewModel = koinViewModel()) {
     val state = vm.state
-    val errorMessage = getErrorMessage(error = state.createAccountError)
-    val titleAlertDialog = getTitleAlertDialog(error = state.createAccountError)
-
 
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         LoadingIndicator(enabled = state.isLoading, modifier = Modifier)
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 30.dp)
+        CreateAccountForm(state, vm, onSignIn)
+    }
+}
+
+@Composable
+private fun CreateAccountForm(
+    state: CreateAccountViewModelState,
+    vm: CreateAccountViewModel,
+    onSignIn: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 30.dp)
+    ) {
+        Text(
+            text = stringResource(Res.string.create_account_title),
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.padding(vertical = 35.dp)
+                .align(alignment = Alignment.CenterHorizontally)
+        )
+
+        Text(
+            text = stringResource(Res.string.sign_up_subtitle),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(vertical = 35.dp)
+        )
+
+        SectionHeader(
+            text = stringResource(Res.string.name_label),
+            icon = Icons.Default.Person
+        )
+        MyOutLinedTextField(
+            text = state.user,
+            label = stringResource(Res.string.full_name_placeholder),
+            onValueChange = { vm.updateParameterStatus(user = it) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        SectionHeader(
+            text = stringResource(Res.string.email_label),
+            icon = Icons.Default.Email,
+            modifier = Modifier.padding(bottom = 5.dp, top = 25.dp)
+        )
+        MyOutLinedTextField(
+            text = state.email,
+            label = stringResource(Res.string.email_placeholder),
+            onValueChange = { vm.updateParameterStatus(email = it) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        SectionHeader(
+            text = stringResource(Res.string.password_label),
+            icon = Icons.Default.Lock,
+            modifier = Modifier.padding(bottom = 5.dp, top = 25.dp)
+        )
+        MyOutLinedTextField(
+            text = state.password,
+            label = stringResource(Res.string.password_placeholder),
+            onValueChange = { vm.updateParameterStatus(password = it) },
+            isPasswordField = true, modifier = Modifier.fillMaxWidth()
+        )
+
+        MyButton(
+            text = stringResource(Res.string.create_account_button),
+            enabled = true,
+            onClick = { vm.createAccount() },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+                .fillMaxWidth().padding(bottom = 30.dp, top = 30.dp)
+        )
+
+        Row(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.Center
         ) {
+            Text(text = stringResource(Res.string.already_have_account_text))
+            Spacer(modifier = Modifier.width(4.dp))
             Text(
-                text = stringResource(Res.string.create_account_title),
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                color = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.padding(vertical = 35.dp)
-                    .align(alignment = Alignment.CenterHorizontally)
-            )
-
-            Text(
-                text = stringResource(Res.string.sign_up_subtitle),
-                style = MaterialTheme.typography.titleMedium,
+                text = stringResource(Res.string.sign_in_link),
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(vertical = 35.dp)
-            )
-
-            Row(
-                modifier = Modifier.padding(bottom = 5.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = stringResource(Res.string.name_label)
-                )
-                Text(text = stringResource(Res.string.name_label))
-            }
-            MyOutLinedTextField(
-                text = state.user,
-                label = stringResource(Res.string.full_name_placeholder),
-                onValueChange = { vm.updateParameterStatus(user = it) },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Row(
-                modifier = Modifier.padding(bottom = 5.dp, top = 25.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Email,
-                    contentDescription = stringResource(Res.string.email_label)
-                )
-                Text(text = stringResource(Res.string.email_label))
-            }
-            MyOutLinedTextField(
-                text = state.email,
-                label = stringResource(Res.string.email_placeholder),
-                onValueChange = { vm.updateParameterStatus(email = it) },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Row(
-                modifier = Modifier.padding(bottom = 5.dp, top = 25.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Lock,
-                    contentDescription = stringResource(Res.string.password_label)
-                )
-                Text(text = stringResource(Res.string.password_label))
-            }
-            MyOutLinedTextField(
-                text = state.password,
-                label = stringResource(Res.string.password_placeholder),
-                onValueChange = { vm.updateParameterStatus(password = it) },
-                isPasswordField = true, modifier = Modifier.fillMaxWidth()
-            )
-
-            MyButton(
-                text = stringResource(Res.string.create_account_button),
-                onClick = { vm.createAccount() },
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-                    .fillMaxWidth().padding(bottom = 30.dp, top = 30.dp)
-            )
-
-            Row(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Text(text = stringResource(Res.string.already_have_account_text))
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = stringResource(Res.string.sign_in_link),
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable(onClick = { onSignIn() })
-                )
-            }
-            MyAlertDialog(
-                showDialog = state.showDialog && errorMessage.isNotEmpty(),
-                title = titleAlertDialog,
-                text = errorMessage,
-                onDismiss = { vm.onDialogDismiss() },
-                onConfirm = { vm.onDialogDismiss() }
+                modifier = Modifier.clickable(onClick = { onSignIn() })
             )
         }
+        MyAlertDialog(
+            showDialog = state.showDialog,
+            title = getTitleAlertDialog(error = state.createAccountError),
+            text = getErrorMessage(error = state.createAccountError),
+            alertType = getAlertType(error = state.createAccountError),
+            onDismiss = { vm.onDialogDismiss() },
+            onConfirm = { vm.onDialogDismiss() }
+        )
     }
 }
 
@@ -185,22 +176,11 @@ private fun getTitleAlertDialog(error: CreateAccountError): String {
 }
 
 @Composable
-private fun MyButton(
-    text: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Button(
-        onClick = { onClick() },
-        modifier = modifier,
-        shape = RoundedCornerShape(8.dp)
-    ) {
-        Text(text = text)
+private fun getAlertType(error: CreateAccountError): AlertType {
+    return when (error) {
+        CreateAccountError.EMPTY_FIELDS -> AlertType.ERROR
+        CreateAccountError.ACCOUNT_CREATED -> AlertType.SUCCESS
+        CreateAccountError.ACCOUNT_CREATED_ERROR -> AlertType.ERROR
+        CreateAccountError.OK -> AlertType.INFO
     }
 }
-
-/*@Preview(showBackground = true)
-@Composable
-fun CreateAccountViewPreview() {
-    CreateAccountView()
-}**/

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/login/Login.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/login/Login.kt
@@ -1,7 +1,7 @@
 package jva.cloud.democomposemultiplatform.presentation.views.login
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,9 +9,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,13 +28,17 @@ import democomposemultiplatform.composeapp.generated.resources.error_title
 import democomposemultiplatform.composeapp.generated.resources.login_error_empty_fields
 import democomposemultiplatform.composeapp.generated.resources.login_error_invalid_credentials
 import democomposemultiplatform.composeapp.generated.resources.login_title
+import democomposemultiplatform.composeapp.generated.resources.name_label
 import democomposemultiplatform.composeapp.generated.resources.new_to_app_text
 import democomposemultiplatform.composeapp.generated.resources.password_label
 import democomposemultiplatform.composeapp.generated.resources.sign_in_button
 import democomposemultiplatform.composeapp.generated.resources.user_label
 import jva.cloud.democomposemultiplatform.presentation.components.LoadingIndicator
 import jva.cloud.democomposemultiplatform.presentation.components.MyAlertDialog
+import jva.cloud.democomposemultiplatform.presentation.components.MyButton
 import jva.cloud.democomposemultiplatform.presentation.components.MyOutLinedTextField
+import jva.cloud.democomposemultiplatform.presentation.components.SectionHeader
+import jva.cloud.democomposemultiplatform.presentation.components.model.AlertType
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.login.LoginError
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.login.LoginViewModel
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.login.LoginViewModelState
@@ -51,32 +56,50 @@ fun LoginView(
     viewModel: LoginViewModel = koinViewModel()
 ) {
     val state: LoginViewModelState = viewModel.state
-    val errorMessage = getErrorMessage(loginError = state.loginError)
 
-    MyAlertDialog(
-        showDialog = state.showDialog && errorMessage.isNotEmpty(),
-        title = stringResource(Res.string.error_title),
-        text = errorMessage,
-        onDismiss = { viewModel.onDialogDismiss() },
-        onConfirm = { viewModel.onDialogDismiss() }
-    )
-
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(
-            15.dp,
-            Alignment.CenterVertically
-        )
-    ) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         LoadingIndicator(enabled = state.isLoading, modifier = Modifier)
+        MyAlertDialog(
+            showDialog = state.showDialog,
+            title = stringResource(Res.string.error_title),
+            text = getErrorMessage(loginError = state.loginError),
+            alertType = AlertType.ERROR,
+            onDismiss = { viewModel.onDialogDismiss() },
+            onConfirm = { viewModel.onDialogDismiss() }
+        )
+
+        LoginForm(state, viewModel, redirectHome, redirectCreateAccount)
+    }
+}
+
+@Composable
+private fun LoginForm(
+    state: LoginViewModelState,
+    viewModel: LoginViewModel,
+    redirectHome: () -> Unit,
+    redirectCreateAccount: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 30.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
         if (state.loggedIn) redirectHome()
         Text(
+            modifier = Modifier.padding(vertical = 35.dp),
             text = stringResource(Res.string.login_title),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold
         )
+        SectionHeader(
+            text = stringResource(Res.string.name_label),
+            icon = Icons.Default.Person,
+            modifier = Modifier.align(Alignment.Start).padding(start = 33.dp)
+        )
         MyOutLinedTextField(
+            modifier = Modifier.padding(bottom = 25.dp),
             text = state.user,
             label = stringResource(Res.string.user_label),
             onValueChange = { viewModel.updateParameterStatus(user = it) },
@@ -85,7 +108,13 @@ fun LoginView(
                 imeAction = ImeAction.Next
             )
         )
+        SectionHeader(
+            text = stringResource(Res.string.password_label),
+            icon = Icons.Default.Lock,
+            modifier = Modifier.align(Alignment.Start).padding(start = 33.dp)
+        )
         MyOutLinedTextField(
+            modifier = Modifier.padding(bottom = 25.dp),
             text = state.password,
             label = stringResource(Res.string.password_label),
             onValueChange = { viewModel.updateParameterStatus(password = it) },
@@ -97,7 +126,7 @@ fun LoginView(
             onClick = { viewModel.login() },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 55.dp)
+                .padding(horizontal = 30.dp)
         )
 
         Row {
@@ -122,27 +151,3 @@ private fun getErrorMessage(loginError: LoginError?): String {
         }
     } ?: ""
 }
-
-@Composable
-private fun MyButton(
-    text: String,
-    enabled: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Button(
-        enabled = enabled,
-        onClick = { onClick() },
-        modifier = modifier,
-        shape = RoundedCornerShape(8.dp)
-    ) {
-        Text(text = text)
-    }
-}
-
-/*@Preview(showBackground = true)
-@Composable
-fun LoginPreview() {
-    val viewModel: LoginViewModel = LoginViewModel()
-    LoginView(viewModel = viewModel)
-}**/


### PR DESCRIPTION
- Add new reusable composable `MyButton` for consistent button styling.
- Create `SectionHeader` composable to standardize section titles with icons.
- Refactor `CreateAccountView` and `LoginView` to use the new `MyButton` and `SectionHeader` components, reducing code duplication.
- Introduce `AlertType` enum (`SUCCESS`, `ERROR`, `INFO`) to manage different alert dialog states.
- Enhance `MyAlertDialog` to display different icons and buttons based on the `AlertType`.