### PR TITLE
feat: Enhance navigation and image loading

### DIFF
--- a/composeApp/src/androidMain/kotlin/jva/cloud/democomposemultiplatform/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/jva/cloud/democomposemultiplatform/MainActivity.kt
@@ -4,14 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import jva.cloud.democomposemultiplatform.presentation.components.SetupImageLoader
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
-            SetupImageLoader()
             App()
         }
     }

--- a/composeApp/src/commonMain/composeResources/drawable/ic_broken_image.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_broken_image.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="300dp" android:tint="#0100C8" android:viewportHeight="24" android:viewportWidth="24" android:width="300dp">
+      
+    <path android:fillColor="#FFFFFF" android:pathData="M21,5v6.59l-3,-3.01 -4,4.01 -4,-4 -4,4 -3,-3.01L3,5c0,-1.1 0.9,-2 2,-2h14c1.1,0 2,0.9 2,2zM18,11.42l3,3.01L21,19c0,1.1 -0.9,2 -2,2L5,21c-1.1,0 -2,-0.9 -2,-2v-6.58l3,2.99 4,-4 4,4 4,-3.99z"/>
+    
+</vector>

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/App.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/App.kt
@@ -10,12 +10,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import jva.cloud.democomposemultiplatform.presentation.components.SetupImageLoader
 import jva.cloud.democomposemultiplatform.presentation.views.nav.Navigation
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-@Preview(showBackground = true)
 fun App() {
+    SetupImageLoader()
     val isDarkTheme = isSystemInDarkTheme()
     val colorScheme = if (isDarkTheme) darkColorScheme() else lightColorScheme()
 

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/home/Home.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/home/Home.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import democomposemultiplatform.composeapp.generated.resources.Res
+import democomposemultiplatform.composeapp.generated.resources.ic_broken_image
 import democomposemultiplatform.composeapp.generated.resources.log_out_button
 import democomposemultiplatform.composeapp.generated.resources.products_title
 import jva.cloud.democomposemultiplatform.domain.model.Product
@@ -35,6 +36,7 @@ import jva.cloud.democomposemultiplatform.presentation.components.LoadingIndicat
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.home.HomeVieMode
 import jva.cloud.democomposemultiplatform.utils.UtilsApp.reprocessImageFromApi
 import kotlinx.serialization.Serializable
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -88,7 +90,8 @@ private fun ProductItem(goToDetail: (Int) -> Unit, product: Product) {
             model = reprocessImageFromApi(product.images),
             contentDescription = product.title,
             contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize().aspectRatio(2 / 3f).clip(MaterialTheme.shapes.small)
+            modifier = Modifier.fillMaxSize().aspectRatio(2 / 3f).clip(MaterialTheme.shapes.small),
+            error = painterResource(resource = Res.drawable.ic_broken_image)
         )
         Text(text = product.title, style = MaterialTheme.typography.titleMedium)
     }

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/homedetail/HomeDetail.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/homedetail/HomeDetail.kt
@@ -30,12 +30,14 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import democomposemultiplatform.composeapp.generated.resources.Res
 import democomposemultiplatform.composeapp.generated.resources.back_content_description
+import democomposemultiplatform.composeapp.generated.resources.ic_broken_image
 import democomposemultiplatform.composeapp.generated.resources.product_details_title
 import jva.cloud.democomposemultiplatform.domain.model.Product
 import jva.cloud.democomposemultiplatform.presentation.components.LoadingIndicator
 import jva.cloud.democomposemultiplatform.presentation.viewmodel.homedetail.HomeDetailVieModel
 import jva.cloud.democomposemultiplatform.utils.UtilsApp.reprocessImageFromApi
 import kotlinx.serialization.Serializable
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Serializable
@@ -90,7 +92,8 @@ private fun ProductDetailContent(product: Product, paddingValues: PaddingValues)
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .aspectRatio(4f / 3f)
+                        .aspectRatio(4f / 3f),
+                    error = painterResource(resource = Res.drawable.ic_broken_image)
                 )
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/nav/Navigation.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/presentation/views/nav/Navigation.kt
@@ -1,5 +1,7 @@
 package jva.cloud.democomposemultiplatform.presentation.views.nav
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -18,26 +20,67 @@ import org.koin.core.parameter.parametersOf
 
 @Composable
 fun Navigation(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = Login) {
+    NavHost(
+        navController = navController, startDestination = Login
+    ) {
         composable<Login> {
             LoginView(
-                redirectHome = { navController.navigate(Home) },
+                redirectHome = {
+                    navController.navigate(Home, builder = {
+                        popUpTo(Login) {
+                            inclusive = true
+                        }
+                    })
+                },
                 redirectCreateAccount = { navController.navigate(CreateAccount) })
         }
 
-        composable<CreateAccount> { CreateAccountView(onSignIn = { navController.navigate(Login) }) }
+        composable<CreateAccount>(enterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(400)
+            )
+        }, exitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                animationSpec = tween(400)
+            )
+        }) {
+            CreateAccountView(onSignIn = {
+                navController.navigate(
+                    Login,
+                    builder = { popUpTo<CreateAccount> { inclusive = true } })
+            })
+        }
 
         composable<Home> {
             HomeView(
                 goToDetail = { navController.navigate(HomeDetail(id = it)) },
-                goToLogin = { navController.navigate(Login) })
+                goToLogin = {
+                    navController.navigate(Login, builder = {
+                        popUpTo<Home> { inclusive = true }
+                    })
+                })
         }
 
-        composable<HomeDetail> { backStackEntry ->
+        composable<HomeDetail>(
+            enterTransition = {
+                slideIntoContainer(
+                    towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                    animationSpec = tween(500)
+                )
+            },
+            exitTransition = {
+                slideOutOfContainer(
+                    towards = AnimatedContentTransitionScope.SlideDirection.End,
+                    animationSpec = tween(500)
+                )
+            }
+        ) { backStackEntry ->
             val homeDetail = backStackEntry.toRoute<HomeDetail>()
             HomeDetailView(
                 vm = koinViewModel(parameters = { parametersOf(homeDetail.id) }),
-                onBack = { navController.navigate(Home) }
+                onBack = { navController.popBackStack() }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/utils/ConstantApp.kt
+++ b/composeApp/src/commonMain/kotlin/jva/cloud/democomposemultiplatform/utils/ConstantApp.kt
@@ -8,9 +8,9 @@ object ConstantApp {
 
     //ktor-fake-api-config
     const val BASE_URL_HOST_FAKE_API = "api.escuelajs.co"
-    const val REQUEST_TIMEOUT_MILLIS = 2000L
-    const val CONNECT_TIMEOUT_MILLIS = 2000L
-    const val SOCKET_TIMEOUT_MILLIS = 2000L
+    const val REQUEST_TIMEOUT_MILLIS = 5000L
+    const val CONNECT_TIMEOUT_MILLIS = 5000L
+    const val SOCKET_TIMEOUT_MILLIS = 5000L
     const val KTOR_LOGGER = "Ktor Logger"
 
     //ktor-product


### PR DESCRIPTION
This commit introduces several improvements, including animated screen transitions, enhanced navigation logic, and more robust image loading.

Key changes:
- Implemented animated transitions for navigating between screens.
- Refactored navigation logic to properly manage the back stack, such as clearing the stack after login/logout and using `popBackStack` for "back" actions.
- Centralized the `ImageLoader` setup by moving it from the Android-specific `MainActivity` to the common `App` composable.
- Added a placeholder drawable for broken images in `AsyncImage` components on the Home and Home Detail screens.
- Increased the Ktor client's network timeout values from 2000ms to 5000ms to improve reliability on slower connections.